### PR TITLE
Fix pop-tarts: textured box instead of scanned mesh

### DIFF
--- a/src/prl_assets/objects/pop_tarts/pop_tarts.xml
+++ b/src/prl_assets/objects/pop_tarts/pop_tarts.xml
@@ -4,14 +4,13 @@
   <asset>
     <texture name="pop_tarts_tex" type="2d" file="pop_tarts_visual_0.png"/>
     <material name="pop_tarts_mat" texture="pop_tarts_tex"/>
-    <mesh name="pop_tarts_visual" file="pop_tarts_visual.obj" scale="1 1 1"/>
   </asset>
 
   <worldbody>
     <body name="pop_tarts" pos="0 0 0.0703">
       <freejoint name="pop_tarts_joint"/>
 
-      <!-- Collision geometry - box approximation -->
+      <!-- Collision geometry -->
       <geom name="pop_tarts_collision"
             type="box"
             size="0.0463 0.0487 0.0703"
@@ -21,19 +20,10 @@
             conaffinity="1"
             rgba="0 0 0 0"/>
 
-      <!-- Visual mesh -->
+      <!-- Visual: textured box (replaces scanned mesh whose texture was rotated) -->
       <geom name="pop_tarts_visual"
-            type="mesh"
-            mesh="pop_tarts_visual"
-            material="pop_tarts_mat"
-            contype="0"
-            conaffinity="0"/>
-
-      <!-- Bottom cap (mesh scan has no bottom face) -->
-      <geom name="pop_tarts_bottom"
             type="box"
-            size="0.0463 0.0487 0.0005"
-            pos="0 0 -0.0703"
+            size="0.0463 0.0487 0.0703"
             material="pop_tarts_mat"
             contype="0"
             conaffinity="0"/>


### PR DESCRIPTION
## Summary

- Replace scanned mesh visual with a box primitive matching collision geometry
- The scanned mesh had a rotated texture and no bottom face
- MuJoCo wraps the texture cleanly around all 6 faces of the box — no more garbled bottom

## Test plan

- [ ] Visual check: pop-tarts texture looks correct on all faces including bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)