### PR TITLE
Fix plastic_glass floating: body origin at center, not bottom

### DIFF
--- a/src/prl_assets/objects/plastic_glass/plastic_glass.xml
+++ b/src/prl_assets/objects/plastic_glass/plastic_glass.xml
@@ -7,13 +7,12 @@
   </asset>
 
   <worldbody>
-    <body name="plastic_glass" pos="0 0 0">
+    <body name="plastic_glass" pos="0 0 0.0855">
       <freejoint name="plastic_glass_joint"/>
 
       <!-- Collision geometry - cylinder (radius=0.048, height=0.171) -->
       <geom name="plastic_glass_collision"
             type="cylinder"
-            pos="0 0 0.0855"
             size="0.048 0.0855"
             mass="0.08"
             friction="0.6 0.005 0.0001"


### PR DESCRIPTION
## Bug

plastic_glass body origin was at z=0 (bottom) with the collision geom offset up by half-height. All other objects use body origin at geometric center. This caused the glass to float half a height above the worktop when spawned.

## Fix

Move body `pos` to `0 0 0.0855` (half-height) and remove the geom `pos` offset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)