### PR TITLE
Fix plastic_glass visual offset after origin fix

### DIFF
--- a/src/prl_assets/objects/plastic_glass/plastic_glass.xml
+++ b/src/prl_assets/objects/plastic_glass/plastic_glass.xml
@@ -20,10 +20,11 @@
             conaffinity="1"
             rgba="0 0 0 0"/>
 
-      <!-- Visual mesh -->
+      <!-- Visual mesh (mesh origin at bottom, shift down to center on body) -->
       <geom name="plastic_glass_visual"
             type="mesh"
             mesh="plastic_glass_mesh"
+            pos="0 0 -0.0855"
             material="plastic_glass_mat"
             contype="0"
             conaffinity="0"/>


### PR DESCRIPTION
Follow-up to #10. The visual mesh was modeled with bottom at z=0. After moving the body origin to center, the mesh needs `pos="0 0 -0.0855"` to align with the collision cylinder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)