### PR TITLE
Standardize outer_dimensions → outer_size

### DIFF
--- a/src/prl_assets/objects/recycle_bin/meta.yaml
+++ b/src/prl_assets/objects/recycle_bin/meta.yaml
@@ -11,8 +11,8 @@ material: plastic
 # Geometric properties
 geometric_properties:
   type: open_box
-  outer_dimensions: [0.25, 0.25, 0.80]
-  inner_dimensions: [0.244, 0.244, 0.794]
+  outer_size: [0.25, 0.25, 0.80]
+  inner_size: [0.244, 0.244, 0.794]
   wall_thickness: 0.003
 
 # MuJoCo simulation


### PR DESCRIPTION
recycle_bin was the only object using outer_dimensions. All others use outer_size. Standardize to outer_size.