### PR TITLE
plastic_plate: align body origin with geometric center

### DIFF
--- a/src/prl_assets/objects/plastic_plate/plastic_plate.xml
+++ b/src/prl_assets/objects/plastic_plate/plastic_plate.xml
@@ -10,10 +10,19 @@
     <body name="plastic_plate" pos="0 0 0">
       <freejoint name="plastic_plate_joint"/>
 
+      <!-- The plate OBJ is an open surface mesh, so MuJoCo's mesh loader
+           can't compute a true centroid. Its inertia-frame fallback puts
+           the body origin at the bottom of the rotated mesh (y_min, which
+           becomes z_min after the inertia-frame rotation). We shift both
+           geoms down by half the plate thickness (0.0135 m) so the body
+           origin lands at the geometric center, matching the convention
+           that placement TSRs assume (subject body origin = COM). -->
+
       <!-- Collision mesh (enables stacking) -->
       <geom name="plastic_plate_collision"
             type="mesh"
             mesh="plastic_plate_mesh"
+            pos="0 0 -0.0135"
             mass="0.12"
             friction="0.6 0.005 0.0001"
             solref="0.004 1"
@@ -26,6 +35,7 @@
       <geom name="plastic_plate_visual"
             type="mesh"
             mesh="plastic_plate_mesh"
+            pos="0 0 -0.0135"
             material="plastic_plate_mat"
             contype="0"
             conaffinity="0"/>


### PR DESCRIPTION
## Summary

Shifts the visual and collision geoms of `plastic_plate` by half the plate thickness (0.0135 m) so the body origin coincides with the plate's geometric center.

## Why

The OBJ for `plastic_plate` is an open surface mesh (no closed-volume bottom face), so MuJoCo's mesh loader can't compute a true centroid. Its inertia-frame fallback puts the body origin at the bottom of the rotated mesh rather than at the center.

This violates the convention placement TSRs use (`tsr.placement.StablePlacer.place_cylinder(r, h)` assumes the subject body origin sits at the geometric center, so its `Tw_e` has translation `[0, 0, h/2]`). With the unfixed model, placing the plate via `StablePlacer.place_cylinder(0.133, 0.027)` on a table leaves the plate floating 13.5 mm above the supporting surface.

After the shift, the plate body z equals the surface it rests on.

## Test plan

- [x] All 17 existing prl_assets tests pass.
- [x] After the fix, the visual mesh's world AABB is `[body_z − 0.0135, body_z + 0.0135]` (symmetric around body origin).
- [x] Confirmed end-to-end in the ada_mj table demo: plate now rests cleanly on the table top instead of floating.